### PR TITLE
Close Jimfs when closing the validator

### DIFF
--- a/validator-api/src/main/java/no/difi/vefa/validator/api/SourceInstance.java
+++ b/validator-api/src/main/java/no/difi/vefa/validator/api/SourceInstance.java
@@ -1,5 +1,6 @@
 package no.difi.vefa.validator.api;
 
+import java.io.IOException;
 import java.nio.file.FileSystem;
 
 /**
@@ -13,5 +14,7 @@ public interface SourceInstance {
      * @return Filesystem instance.
      */
     FileSystem getFileSystem();
+    
+    void close() throws IOException;
 
 }

--- a/validator-core/src/main/java/no/difi/vefa/validator/ValidatorEngine.java
+++ b/validator-core/src/main/java/no/difi/vefa/validator/ValidatorEngine.java
@@ -64,10 +64,14 @@ class ValidatorEngine {
      */
     private List<PackageType> packages = new ArrayList<>();
 
+    private SourceInstance sourceInstance;
+    
     /**
      * Loading a new validator engine loading configurations from current source.
      */
     ValidatorEngine(SourceInstance sourceInstance) throws ValidatorException {
+        this.sourceInstance = sourceInstance;
+        
         // Matcher to find configuration files.
         final PathMatcher matcher = sourceInstance.getFileSystem().getPathMatcher("glob:**/config*.xml");
 
@@ -229,5 +233,9 @@ class ValidatorEngine {
     public Path getResource(String resource) throws IOException {
         String[] parts = resource.split("#", 2);
         return configurationSourceMap.get(parts[0]).resolve(parts[1]);
+    }
+    
+    public void close() throws IOException {
+        sourceInstance.close();
     }
 }

--- a/validator-core/src/main/java/no/difi/vefa/validator/ValidatorInstance.java
+++ b/validator-core/src/main/java/no/difi/vefa/validator/ValidatorInstance.java
@@ -6,11 +6,13 @@ import no.difi.xsd.vefa.validator._1.FileType;
 import no.difi.xsd.vefa.validator._1.FlagType;
 import no.difi.xsd.vefa.validator._1.PackageType;
 import no.difi.xsd.vefa.validator._1.StylesheetType;
+
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.List;
@@ -187,5 +189,11 @@ class ValidatorInstance implements Closeable {
     public void close() {
         checkerPool.clear();
         rendererPool.clear();
+        try {
+            validatorEngine.close();
+        } catch (IOException e) {
+            logger.info("Failed to close validator engine", e);
+        }
+            
     }
 }

--- a/validator-core/src/main/java/no/difi/vefa/validator/source/AbstractSourceInstance.java
+++ b/validator-core/src/main/java/no/difi/vefa/validator/source/AbstractSourceInstance.java
@@ -89,4 +89,12 @@ abstract class AbstractSourceInstance implements SourceInstance {
     public FileSystem getFileSystem() {
         return fileSystem;
     }
+    
+    @Override
+    public void close() throws IOException {
+        if (fileSystem != null) {
+            fileSystem.close();
+            fileSystem = null;
+        }
+    }
 }

--- a/validator-core/src/test/java/no/difi/vefa/validator/MultipleValidators.java
+++ b/validator-core/src/test/java/no/difi/vefa/validator/MultipleValidators.java
@@ -1,0 +1,32 @@
+package no.difi.vefa.validator;
+
+import no.difi.vefa.validator.source.RepositorySource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MultipleValidators {
+    private Validator validator;
+    
+    @Before
+    public void setup() throws Exception {
+        validator = ValidatorBuilder.newValidator()
+                .setSource(RepositorySource.forTest())
+                .build();
+    }
+    
+    @After
+    public void cleanup() {
+        validator.close();
+    }
+    
+    @Test
+    public void test1() {
+    }
+    
+    @Test
+    public void test2() {
+    }
+    
+}


### PR DESCRIPTION
If you create multiple ValidatorInstances, e.g., in separate JUnit tests, creation of the second ValidatorInstance will fail. It will get a FileSystemAlreadyExistsException:
```java
Caused by: java.nio.file.FileSystemAlreadyExistsException: jimfs://vefa
	at com.google.common.jimfs.JimfsFileSystemProvider.newFileSystem(JimfsFileSystemProvider.java:114) ~[jimfs-1.0.jar:na]
	at no.difi.vefa.validator.source.AbstractSourceInstance.<init>(AbstractSourceInstance.java:51) ~[validator-core-2.0.1.jar:na]
```
This pull requests makes the ValidatorInstance.close method also close the file system. 