### PR TITLE
Added string input wrapper for the validate method.

### DIFF
--- a/validator-core/src/main/java/no/difi/vefa/validator/Validator.java
+++ b/validator-core/src/main/java/no/difi/vefa/validator/Validator.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 
@@ -105,7 +106,16 @@ public class Validator implements Closeable {
     public Validation validate(ValidationSource validationSource) {
         return new ValidationImpl(this.validatorInstance, validationSource);
     }
-
+    /**
+     * Validate file from filePath string
+     *
+     * @param filePath string representing filePath
+     * @return Validation result
+     * @throws IOException
+     */
+    public Validation validate(String filePath) throws IOException{
+        return validate(Paths.get(filePath));
+    }
     /**
      * List of packages supported by validator.
      *


### PR DESCRIPTION
This makes it easier for us to use this with .NET.
In our effort to port the validator to .NET, this makes it easier to use and not depend upon knowledge of Java specific types, such as the Path object.

It enables us to call it with just base .NET types.